### PR TITLE
Removing period after CLI command

### DIFF
--- a/_posts/2017-09-15-rust-blog-series-1.md
+++ b/_posts/2017-09-15-rust-blog-series-1.md
@@ -107,7 +107,7 @@ From your CLI
 
 [diesel_cli]: https://github.com/diesel-rs/diesel/tree/master/diesel_cli
 
-> `cargo install diesel_cli --no-default-features --features postgres`.
+> `cargo install diesel_cli --no-default-features --features postgres`
 
 The reason we pass both of those long flags to install is because by default,
 Diesel will assume you want all `sqlite`, `mysql`, and  `postgresql` backends.


### PR DESCRIPTION
Because it looks like part of the command but isn't.