### PR TITLE
Fix code overflow

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -73,4 +73,5 @@ blockquote {
 .highlight {
   padding: 1rem;
   background-color:#3f3f3f;
+  overflow: auto;
 }


### PR DESCRIPTION
Change the code sections to be `overflow: auto` so the code doesn't bleed over the edge and look weird.